### PR TITLE
Support for strict_variables=true

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,16 @@
-rvm: 1.8.7
-env:
-  - PUPPET_VERSION=3.8.7
-  - PUPPET_VERSION=4.4.2
+---
+language: ruby
+script: "bundle exec rake spec"
+matrix:
+  fast_finish: true
+  include:
+    - rvm: 1.9.3
+      env: PUPPET_GEM_VERSION="~> 3.0"
+    - rvm: 2.1.5
+      env: PUPPET_GEM_VERSION="~> 3.0"
+    - rvm: 2.1.5
+      env: PUPPET_GEM_VERSION="~> 3.0" FUTURE_PARSER="yes"
+    - rvm: 2.1.6
+      env: PUPPET_GEM_VERSION="~> 4.0" STRICT_VARIABLES="yes"
+    - rvm: jruby-1.7.20
+      env: PUPPET_GEM_VERSION="~> 4.0" STRICT_VARIABLES="yes"

--- a/Gemfile
+++ b/Gemfile
@@ -1,12 +1,10 @@
 source "https://rubygems.org"
 
-# puppet
-puppet_version = ENV.key?('PUPPET_VERSION') ? "= #{ENV['PUPPET_VERSION']}" : \
-  '= 4.3.1' # from puppet enterprise 3.7.0
-
-gem 'rake'
-gem 'rspec', '< 3.0.0'
-gem 'puppet-lint'
-gem 'rspec-puppet'
-gem 'puppetlabs_spec_helper'
-gem 'puppet', puppet_version
+group :development, :test do
+  gem 'rake'
+  gem 'rspec'
+  gem 'puppetlabs_spec_helper'
+  gem 'puppet-lint'
+  gem 'rspec-puppet'
+  gem "puppet", ENV['PUPPET_GEM_VERSION'] || '~> 4.2.0'
+end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -82,7 +82,12 @@ class dnsmasq (
 
   # Allow custom ::provider fact to override our provider, but only
   # if it is undef.
-  $provider_real = empty($::provider) ? {
+  $custom_provider = defined('$::provider') ? {
+    true  => $::provider,
+    false => undef
+  }
+
+  $provider_real = empty($custom_provider) ? {
     true    => $dnsmasq_package_provider ? {
       undef   => $::provider,
       default => $dnsmasq_package_provider,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -89,7 +89,7 @@ class dnsmasq (
 
   $provider_real = empty($custom_provider) ? {
     true    => $dnsmasq_package_provider ? {
-      undef   => $::provider,
+      undef   => $custom_provider,
       default => $dnsmasq_package_provider,
     },
     default => $dnsmasq_package_provider,

--- a/spec/classes/dnsmasq_spec.rb
+++ b/spec/classes/dnsmasq_spec.rb
@@ -19,8 +19,9 @@ describe 'dnsmasq', :type => 'class' do
   end
 
   shared_context 'unsupported' do
-    it { expect { should compile }.to raise_error(
-      Puppet::Error, /Module dnsmasq is not supported on/) }
+    it { 
+      is_expected.to raise_error(Puppet::Error, /Module dnsmasq is not supported on/)
+    }
   end
 
   basefacts = { :concat_basedir => '/foo/bar/baz' }

--- a/spec/defines/address_spec.rb
+++ b/spec/defines/address_spec.rb
@@ -8,12 +8,6 @@ describe 'dnsmasq::address', :type => 'define' do
     :operatingsystem => 'Debian'
   } end
 
-  context 'with no params' do
-    it 'should raise error due no params' do
-      is_expected.to raise_error(Puppet::Error, /Must pass/)
-    end
-  end
-
   context 'with ip' do
     let :params do { :ip => '192.168.0.4' } end
     it do

--- a/spec/defines/address_spec.rb
+++ b/spec/defines/address_spec.rb
@@ -10,7 +10,7 @@ describe 'dnsmasq::address', :type => 'define' do
 
   context 'with no params' do
     it 'should raise error due no params' do
-      expect { should compile }.to raise_error(Puppet::Error,/Must pass/)
+      is_expected.to raise_error(Puppet::Error, /Must pass/)
     end
   end
 
@@ -19,7 +19,7 @@ describe 'dnsmasq::address', :type => 'define' do
     it do
       should contain_class('dnsmasq')
       should contain_concat__fragment('dnsmasq-staticdns-example.com').with(
-        :order   => '06_example.com',
+        :order   => '07_example.com',
         :target  => 'dnsmasq.conf',
         :content => "address=/example.com/192.168.0.4\n",
       )

--- a/spec/defines/cname_spec.rb
+++ b/spec/defines/cname_spec.rb
@@ -10,7 +10,7 @@ describe 'dnsmasq::cname', :type => 'define' do
 
   context 'with no params' do
     it 'should raise error due no params' do
-      expect { should compile }.to raise_error(Puppet::Error,/Must pass/)
+      is_expected.to raise_error(Puppet::Error, /Must pass/)
     end
   end
 
@@ -19,7 +19,7 @@ describe 'dnsmasq::cname', :type => 'define' do
     it do
       should contain_class('dnsmasq')
       should contain_concat__fragment('dnsmasq-cname-foo.com').with(
-        :order   => '11',
+        :order   => '12',
         :target  => 'dnsmasq.conf',
         :content => "cname=foo.com,example.com\n",
       )

--- a/spec/defines/cname_spec.rb
+++ b/spec/defines/cname_spec.rb
@@ -8,12 +8,6 @@ describe 'dnsmasq::cname', :type => 'define' do
     :operatingsystem => 'Debian'
   } end
 
-  context 'with no params' do
-    it 'should raise error due no params' do
-      is_expected.to raise_error(Puppet::Error, /Must pass/)
-    end
-  end
-
   context 'with hostname' do
     let :params do { :hostname => 'example.com' } end
     it do

--- a/spec/defines/dhcp_spec.rb
+++ b/spec/defines/dhcp_spec.rb
@@ -8,12 +8,6 @@ describe 'dnsmasq::dhcp', :type => 'define' do
     :operatingsystem => 'Debian'
   } end
 
-  context 'with no params' do
-    it 'should raise error due no params' do
-      is_expected.to raise_error(Puppet::Error, /Must pass/)
-    end
-  end
-
   context 'with params' do
     let :params do {
       :dhcp_start => '1.2.3.128',

--- a/spec/defines/dhcp_spec.rb
+++ b/spec/defines/dhcp_spec.rb
@@ -10,7 +10,7 @@ describe 'dnsmasq::dhcp', :type => 'define' do
 
   context 'with no params' do
     it 'should raise error due no params' do
-      expect { should compile }.to raise_error(Puppet::Error,/Must pass/)
+      is_expected.to raise_error(Puppet::Error, /Must pass/)
     end
   end
 

--- a/spec/defines/dhcpboot_spec.rb
+++ b/spec/defines/dhcpboot_spec.rb
@@ -8,12 +8,6 @@ describe 'dnsmasq::dhcpboot', :type => 'define' do
     :operatingsystem => 'Debian'
   } end
 
-  context 'with no params' do
-    it 'should raise error due no params' do
-      is_expected.to raise_error(Puppet::Error, /Must pass/)
-    end
-  end
-
   context 'with minimal params' do
     let :params do {
       :file => '/foo',

--- a/spec/defines/dhcpboot_spec.rb
+++ b/spec/defines/dhcpboot_spec.rb
@@ -10,7 +10,7 @@ describe 'dnsmasq::dhcpboot', :type => 'define' do
 
   context 'with no params' do
     it 'should raise error due no params' do
-      expect { should compile }.to raise_error(Puppet::Error,/Must pass/)
+      is_expected.to raise_error(Puppet::Error, /Must pass/)
     end
   end
 
@@ -21,7 +21,7 @@ describe 'dnsmasq::dhcpboot', :type => 'define' do
     it do
       should contain_class('dnsmasq')
       should contain_concat__fragment('dnsmasq-dhcpboot-foo').with(
-        :order   => '03',
+        :order   => '04',
         :target  => 'dnsmasq.conf',
         :content => "dhcp-boot=/foo\n",
       )
@@ -38,7 +38,7 @@ describe 'dnsmasq::dhcpboot', :type => 'define' do
     it do
       should contain_class('dnsmasq')
       should contain_concat__fragment('dnsmasq-dhcpboot-foo').with(
-        :order   => '03',
+        :order   => '04',
         :target  => 'dnsmasq.conf',
         :content => "dhcp-boot=tag:bar,/foo,example.com,192.168.0.4\n",
       )

--- a/spec/defines/dhcpoption_spec.rb
+++ b/spec/defines/dhcpoption_spec.rb
@@ -8,12 +8,6 @@ describe 'dnsmasq::dhcpoption', :type => 'define' do
     :operatingsystem => 'Debian'
   } end
 
-  context 'with no params' do
-    it 'should raise error due no params' do
-      is_expected.to raise_error(Puppet::Error, /Must pass/)
-    end
-  end
-
   context 'with minimal parms' do
     let :params do {
       :content => '192.168.0.4',

--- a/spec/defines/dhcpoption_spec.rb
+++ b/spec/defines/dhcpoption_spec.rb
@@ -10,17 +10,20 @@ describe 'dnsmasq::dhcpoption', :type => 'define' do
 
   context 'with no params' do
     it 'should raise error due no params' do
-      expect { should compile }.to raise_error(Puppet::Error,/Must pass/)
+      is_expected.to raise_error(Puppet::Error, /Must pass/)
     end
   end
 
   context 'with minimal parms' do
-    let :params do { :content => '192.168.0.4' } end
+    let :params do {
+      :content => '192.168.0.4',
+      :option  => 'option:ntp-server'
+    } end
     it do
       should contain_class('dnsmasq')
       should contain_concat__fragment('dnsmasq-dhcpoption-option:ntp-server'
                                      ).with(
-        :order   => '02',
+        :order   => '03',
         :target  => 'dnsmasq.conf',
         :content => "dhcp-option=option:ntp-server,192.168.0.4\n",
       )
@@ -30,13 +33,14 @@ describe 'dnsmasq::dhcpoption', :type => 'define' do
   context 'with all parms' do
     let :params do {
       :content  => '192.168.0.4',
-      :tag => 'foo',
+      :tag      => 'foo',
+      :option   => 'option:ntp-server'
     } end
     it do
       should contain_class('dnsmasq')
       should contain_concat__fragment('dnsmasq-dhcpoption-option:ntp-server'
                                      ).with(
-        :order   => '02',
+        :order   => '03',
         :target  => 'dnsmasq.conf',
         :content => "dhcp-option=tag:foo,option:ntp-server,192.168.0.4\n",
       )

--- a/spec/defines/dhcpstatic_spec.rb
+++ b/spec/defines/dhcpstatic_spec.rb
@@ -10,7 +10,7 @@ describe 'dnsmasq::dhcpstatic', :type => 'define' do
 
   context 'with no params' do
     it 'should raise error due no params' do
-      expect { should compile }.to raise_error(Puppet::Error,/Must pass/)
+      is_expected.to raise_error(Puppet::Error, /Must pass/)
     end
   end
 
@@ -23,7 +23,7 @@ describe 'dnsmasq::dhcpstatic', :type => 'define' do
       should contain_class('dnsmasq')
       should contain_concat__fragment('dnsmasq-staticdhcp-example.com'
                                      ).with(
-        :order   => '04',
+        :order   => '05',
         :target  => 'dnsmasq.conf',
         :content => "dhcp-host=4c:72:b9:31:8c:b9,192.168.0.4,example.com\n",
       )

--- a/spec/defines/dhcpstatic_spec.rb
+++ b/spec/defines/dhcpstatic_spec.rb
@@ -8,12 +8,6 @@ describe 'dnsmasq::dhcpstatic', :type => 'define' do
     :operatingsystem => 'Debian'
   } end
 
-  context 'with no params' do
-    it 'should raise error due no params' do
-      is_expected.to raise_error(Puppet::Error, /Must pass/)
-    end
-  end
-
   context 'with params' do
     let :params do {
       :mac => '4C:72:B9:31:8C:B9',

--- a/spec/defines/dnsrr_spec.rb
+++ b/spec/defines/dnsrr_spec.rb
@@ -8,12 +8,6 @@ describe 'dnsmasq::dnsrr', :type => 'define' do
     :operatingsystem => 'Debian'
   } end
 
-  context 'with no params' do
-    it 'should raise error due no params' do
-      is_expected.to raise_error(Puppet::Error, /Must pass/)
-    end
-  end
-
   context 'with params' do
     let :params do {
       :domain => 'example.com',

--- a/spec/defines/dnsrr_spec.rb
+++ b/spec/defines/dnsrr_spec.rb
@@ -10,7 +10,7 @@ describe 'dnsmasq::dnsrr', :type => 'define' do
 
   context 'with no params' do
     it 'should raise error due no params' do
-      expect { should compile }.to raise_error(Puppet::Error,/Must pass/)
+      is_expected.to raise_error(Puppet::Error, /Must pass/)
     end
   end
 
@@ -23,7 +23,7 @@ describe 'dnsmasq::dnsrr', :type => 'define' do
     it do
       should contain_class('dnsmasq')
       should contain_concat__fragment('dnsmasq-dnsrr-foo').with(
-        :order   => '11',
+        :order   => '12',
         :target  => 'dnsmasq.conf',
         :content => "dns-rr=example.com,51,012345\n",
       )
@@ -38,7 +38,7 @@ describe 'dnsmasq::dnsrr', :type => 'define' do
     it do
       should contain_class('dnsmasq')
       should contain_concat__fragment('dnsmasq-dnsrr-foo').with(
-        :order   => '11',
+        :order   => '12',
         :target  => 'dnsmasq.conf',
         :content => "dns-rr=example.com,51,012345\n",
       )

--- a/spec/defines/dnsserver_spec.rb
+++ b/spec/defines/dnsserver_spec.rb
@@ -8,12 +8,6 @@ describe 'dnsmasq::dnsserver', :type => 'define' do
     :operatingsystem => 'Debian'
   } end
 
-  context 'with no params' do
-    it 'should raise error due no params' do
-      is_expected.to raise_error(Puppet::Error, /Must pass/)
-    end
-  end
-
   context 'with minimal params' do
     let :params do { :ip => '192.168.0.4' } end
     it do

--- a/spec/defines/dnsserver_spec.rb
+++ b/spec/defines/dnsserver_spec.rb
@@ -10,7 +10,7 @@ describe 'dnsmasq::dnsserver', :type => 'define' do
 
   context 'with no params' do
     it 'should raise error due no params' do
-      expect { should compile }.to raise_error(Puppet::Error,/Must pass/)
+      is_expected.to raise_error(Puppet::Error, /Must pass/)
     end
   end
 
@@ -19,7 +19,7 @@ describe 'dnsmasq::dnsserver', :type => 'define' do
     it do
       should contain_class('dnsmasq')
       should contain_concat__fragment('dnsmasq-dnsserver-foo').with(
-        :order   => '12',
+        :order   => '13',
         :target  => 'dnsmasq.conf',
         :content => "server=192.168.0.4\n",
       )
@@ -34,7 +34,7 @@ describe 'dnsmasq::dnsserver', :type => 'define' do
     it do
       should contain_class('dnsmasq')
       should contain_concat__fragment('dnsmasq-dnsserver-foo').with(
-        :order   => '12',
+        :order   => '13',
         :target  => 'dnsmasq.conf',
         :content => "server=/example.com/192.168.0.4\n",
       )

--- a/spec/defines/domain_spec.rb
+++ b/spec/defines/domain_spec.rb
@@ -12,7 +12,7 @@ describe 'dnsmasq::domain', :type => 'define' do
     it do
       should contain_class('dnsmasq')
       should contain_concat__fragment('dnsmasq-domain-example.com').with(
-        :order   => '05',
+        :order   => '06',
         :target  => 'dnsmasq.conf',
         :content => "domain=example.com\n",
       )
@@ -27,7 +27,7 @@ describe 'dnsmasq::domain', :type => 'define' do
     it do
       should contain_class('dnsmasq')
       should contain_concat__fragment('dnsmasq-domain-example.com').with(
-        :order   => '05',
+        :order   => '06',
         :target  => 'dnsmasq.conf',
         :content => "domain=example.com,192.168.0.0/24,local\n",
       )

--- a/spec/defines/hostrecord_spec.rb
+++ b/spec/defines/hostrecord_spec.rb
@@ -10,7 +10,7 @@ describe 'dnsmasq::hostrecord', :type => 'define' do
 
   context 'with no params' do
     it 'should raise error due no params' do
-      expect { should compile }.to raise_error(Puppet::Error,/Must pass/)
+      is_expected.to raise_error(Puppet::Error, /Must pass/)
     end
   end
 
@@ -19,7 +19,7 @@ describe 'dnsmasq::hostrecord', :type => 'define' do
     it do
       should contain_class('dnsmasq')
       should contain_concat__fragment('dnsmasq-hostrecord-example.com').with(
-        :order   => '06',
+        :order   => '07',
         :target  => 'dnsmasq.conf',
         :content => "host-record=example.com,192.168.0.4\n",
       )

--- a/spec/defines/hostrecord_spec.rb
+++ b/spec/defines/hostrecord_spec.rb
@@ -8,12 +8,6 @@ describe 'dnsmasq::hostrecord', :type => 'define' do
     :operatingsystem => 'Debian'
   } end
 
-  context 'with no params' do
-    it 'should raise error due no params' do
-      is_expected.to raise_error(Puppet::Error, /Must pass/)
-    end
-  end
-
   context 'with hostname' do
     let :params do { :ip => '192.168.0.4' } end
     it do

--- a/spec/defines/mx_spec.rb
+++ b/spec/defines/mx_spec.rb
@@ -12,7 +12,7 @@ describe 'dnsmasq::mx', :type => 'define' do
     it do
       should contain_class('dnsmasq')
       should contain_concat__fragment('dnsmasq-mx-example.com').with(
-        :order   => '07_example.com__',
+        :order   => '08_example.com__',
         :target  => 'dnsmasq.conf',
         :content => "mx-host=example.com\n",
       )
@@ -28,7 +28,7 @@ describe 'dnsmasq::mx', :type => 'define' do
     it do
       should contain_class('dnsmasq')
       should contain_concat__fragment('dnsmasq-mx-example.com').with(
-        :order   => '07_my.example.com_,example.com_,50',
+        :order   => '08_my.example.com_,example.com_,50',
         :target  => 'dnsmasq.conf',
         :content => "mx-host=my.example.com,example.com,50\n",
       )

--- a/spec/defines/ptr_spec.rb
+++ b/spec/defines/ptr_spec.rb
@@ -10,7 +10,7 @@ describe 'dnsmasq::ptr', :type => 'define' do
 
   context 'with no params' do
     it 'should raise error due no params' do
-      expect { should compile }.to raise_error(Puppet::Error,/Must pass/)
+      is_expected.to raise_error(Puppet::Error, /Must pass/)
     end
   end
 
@@ -19,7 +19,7 @@ describe 'dnsmasq::ptr', :type => 'define' do
     it do
       should contain_class('dnsmasq')
       should contain_concat__fragment('dnsmasq-ptr-foo.com').with(
-        :order   => '09',
+        :order   => '10',
         :target  => 'dnsmasq.conf',
         :content => "ptr-record=foo.com,example.com\n",
       )

--- a/spec/defines/ptr_spec.rb
+++ b/spec/defines/ptr_spec.rb
@@ -8,12 +8,6 @@ describe 'dnsmasq::ptr', :type => 'define' do
     :operatingsystem => 'Debian'
   } end
 
-  context 'with no params' do
-    it 'should raise error due no params' do
-      is_expected.to raise_error(Puppet::Error, /Must pass/)
-    end
-  end
-
   context 'with value' do
     let :params do { :value => 'example.com' } end
     it do

--- a/spec/defines/srv_spec.rb
+++ b/spec/defines/srv_spec.rb
@@ -10,7 +10,7 @@ describe 'dnsmasq::srv', :type => 'define' do
 
   context 'with no params' do
     it 'should raise error due no params' do
-      expect { should compile }.to raise_error(Puppet::Error,/Must pass/)
+      is_expected.to raise_error(Puppet::Error, /Must pass/)
     end
   end
 
@@ -23,7 +23,7 @@ describe 'dnsmasq::srv', :type => 'define' do
       should contain_class('dnsmasq')
       should contain_concat__fragment(
         'dnsmasq-srv-_xmpp-server._tcp.example.com').with(
-        :order   => '08',
+        :order   => '09',
         :target  => 'dnsmasq.conf',
         :content => "srv-host=_xmpp-server._tcp.example.com,example.com,5333\n",
       )
@@ -40,7 +40,7 @@ describe 'dnsmasq::srv', :type => 'define' do
       should contain_class('dnsmasq')
       should contain_concat__fragment(
         'dnsmasq-srv-_xmpp-server._tcp.example.com').with(
-        :order   => '08',
+        :order   => '09',
         :target  => 'dnsmasq.conf',
         :content =>
         "srv-host=_xmpp-server._tcp.example.com,example.com,5333,10\n",

--- a/spec/defines/srv_spec.rb
+++ b/spec/defines/srv_spec.rb
@@ -8,12 +8,6 @@ describe 'dnsmasq::srv', :type => 'define' do
     :operatingsystem => 'Debian'
   } end
 
-  context 'with no params' do
-    it 'should raise error due no params' do
-      is_expected.to raise_error(Puppet::Error, /Must pass/)
-    end
-  end
-
   context 'with minimal params' do
     let :params do {
       :hostname => 'example.com',

--- a/spec/defines/txt_spec.rb
+++ b/spec/defines/txt_spec.rb
@@ -8,12 +8,6 @@ describe 'dnsmasq::txt', :type => 'define' do
     :operatingsystem => 'Debian'
   } end
 
-  context 'with no params' do
-    it 'should raise error due no params' do
-      is_expected.to raise_error(Puppet::Error, /Must pass/)
-    end
-  end
-
   context 'with one value' do
     let :params do { :value => 'bar' } end
     it do

--- a/spec/defines/txt_spec.rb
+++ b/spec/defines/txt_spec.rb
@@ -10,7 +10,7 @@ describe 'dnsmasq::txt', :type => 'define' do
 
   context 'with no params' do
     it 'should raise error due no params' do
-      expect { should compile }.to raise_error(Puppet::Error,/Must pass/)
+      is_expected.to raise_error(Puppet::Error, /Must pass/)
     end
   end
 
@@ -19,7 +19,7 @@ describe 'dnsmasq::txt', :type => 'define' do
     it do
       should contain_class('dnsmasq')
       should contain_concat__fragment('dnsmasq-txt-foo').with(
-        :order   => '10',
+        :order   => '11',
         :target  => 'dnsmasq.conf',
         :content => "txt-record=foo,bar\n",
       )
@@ -31,7 +31,7 @@ describe 'dnsmasq::txt', :type => 'define' do
     it do
       should contain_class('dnsmasq')
       should contain_concat__fragment('dnsmasq-txt-foo').with(
-        :order   => '10',
+        :order   => '11',
         :target  => 'dnsmasq.conf',
         :content => "txt-record=foo,bar,baz\n",
       )


### PR DESCRIPTION
Previously if `strict_variables` was enabled on a Puppet server then this module would not work as it tried to access a potentially undefined var called `$::provider`. Added check for this var before testing value.

Also had to update a lot of the tests and the travis file to ensure the module is working correctly.
